### PR TITLE
docker env fixes

### DIFF
--- a/config/core.js
+++ b/config/core.js
@@ -126,7 +126,7 @@ for (var attr in process.env) {
 }
 
 // lets move it here so changes made to MAX_UPLOAD_SIZE will be displayed correctly.
-if (typeof config.DESCRIPTION == 'undefined') {
+if ('DESCRIPTION' in config) {
   config.DESCRIPTION = "Upload whatever you want here, as long as it's under "+
                        config.MAX_UPLOAD_SIZE/1000000 + "MB.<br/> "+
                        "Please read our <a href='/faq'>FAQ</a>, as we may "+
@@ -135,4 +135,6 @@ if (typeof config.DESCRIPTION == 'undefined') {
 
 // DO NOT TOUCH UNLESS YOU KNOW HOW TO PROPERLY CONFIGURE CORS
 // Changes the file upload form to POST to this URL instead of the one it's loaded from.
-if (typeof config.UPLOAD_URL == 'undefined') config.UPLOAD_URL = config.URL;
+if ('UPLOAD_URL' in config) {
+  config.UPLOAD_URL = config.URL;
+}

--- a/config/core.js
+++ b/config/core.js
@@ -14,7 +14,6 @@ config.MAX_UPLOAD_SIZE = 100000000;
 config.SITE_NAME = 'NPomf';
 config.HELLO = "Ohayō!";
 config.TAGLINE = "More kawaii than Pomf?!";
-// config.DESCRIPTION has moved to the bottom of this configuration.
 
 // Main URL (User-facing)
 // config.URL = 'http://my.domain.is.moe';
@@ -28,10 +27,6 @@ config.URL = 'http://localhost:3000';
 // config.FILE_URL = 'http://a.my.domain.is.moe';
 // Also used to have a trailing / but shouldn't any more!
 config.FILE_URL = 'http://localhost:3000/f';
-
-// DO NOT TOUCH UNLESS YOU KNOW HOW TO PROPERLY CONFIGURE CORS
-// Changes the file upload form to POST to this URL instead of the one it's loaded from.
-config.UPLOAD_URL = config.URL;
 
 // Only open to localhost, you can should put this behind nginx or similar
 // config.IFACES = '0.0.0.0'; // Open to all interfaces (Not running behind nginx)
@@ -137,3 +132,7 @@ if (typeof config.DESCRIPTION == 'undefined') {
                        "Please read our <a href='/faq'>FAQ</a>, as we may "+
                        "remove files under specific circumstances.";
 }
+
+// DO NOT TOUCH UNLESS YOU KNOW HOW TO PROPERLY CONFIGURE CORS
+// Changes the file upload form to POST to this URL instead of the one it's loaded from.
+if (typeof config.UPLOAD_URL == 'undefined') config.UPLOAD_URL = config.URL;

--- a/config/core.js
+++ b/config/core.js
@@ -14,10 +14,7 @@ config.MAX_UPLOAD_SIZE = 100000000;
 config.SITE_NAME = 'NPomf';
 config.HELLO = "Ohayō!";
 config.TAGLINE = "More kawaii than Pomf?!";
-config.DESCRIPTION = "Upload whatever you want here, as long as it's under "+
-                     config.MAX_UPLOAD_SIZE/1000000 + "MB.<br/> "+
-                     "Please read our <a href='/faq'>FAQ</a>, as we may "+
-                     "remove files under specific circumstances.";
+// config.DESCRIPTION has moved to the bottom of this configuration.
 
 // Main URL (User-facing)
 // config.URL = 'http://my.domain.is.moe';
@@ -122,6 +119,21 @@ config.SESSION_OPTIONS = {
 for (var attr in process.env) {
 	if (attr && attr.startsWith('NPOMF_')) {
 		eattr = attr.replace('NPOMF_', '');
-		config[eattr] = process.env[attr];
+    
+    var data = process.env[attr];
+    // lets make it possible to use stuff like CONTACTS in docker environments.
+    try {
+      config[eattr] = JSON.parse(data);
+    } catch (exception) {
+      config[eattr] = data;
+    }
 	}
+}
+
+// lets move it here so changes made to MAX_UPLOAD_SIZE will be displayed correctly.
+if (typeof config.DESCRIPTION == 'undefined') {
+  config.DESCRIPTION = "Upload whatever you want here, as long as it's under "+
+                       config.MAX_UPLOAD_SIZE/1000000 + "MB.<br/> "+
+                       "Please read our <a href='/faq'>FAQ</a>, as we may "+
+                       "remove files under specific circumstances.";
 }


### PR DESCRIPTION
make docker configuration great again

`NPOMF_CONTACTS = ["foo@bar.com", "bar@foo.com"]` etc.

before it was impossible to assign arrays / objects through environment variables.